### PR TITLE
ci(release): use a github app to bypass rules

### DIFF
--- a/.github/workflows/75_release_generate_tag_changelog.yml
+++ b/.github/workflows/75_release_generate_tag_changelog.yml
@@ -16,10 +16,24 @@ jobs:
     env:
       TARGET_BRANCH: ${{ github.ref_name }}
     steps:
+      # Mint a short-lived token for a GitHub App that is on the master
+      # ruleset's bypass list, so the release commits can be pushed to the
+      # protected branch without satisfying the required status checks.
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          # Persist the App token so `git push` authenticates as the App
+          # (the bypass actor) rather than github-actions[bot].
+          token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: true
 
       - name: Determine release version
         run: |


### PR DESCRIPTION
Added a github app called internal-release that bypasses protection rules so I can eat my cake while also being the one in possession of said confectionary.